### PR TITLE
Allow to use '0' and '-' in resultsFile regex. Exclude "/test:abc" strings from rerun command line. Make error messages more descriptive

### DIFF
--- a/MSTest.Console/MSTest.Console.Extended.UnitTests/MsTestTestRunProviderTests/MsTestTestRunProvider_GenerateAdditionalArgumentsForFailedTestsRun_Should.cs
+++ b/MSTest.Console/MSTest.Console.Extended.UnitTests/MsTestTestRunProviderTests/MsTestTestRunProvider_GenerateAdditionalArgumentsForFailedTestsRun_Should.cs
@@ -58,5 +58,24 @@ namespace MSTest.Console.Extended.UnitTests.MsTestTestRunProviderTests
             string additionalArguments = microsoftTestTestRunProvider.GenerateAdditionalArgumentsForFailedTestsRun(testRun.Results.ToList(), newTestResultsPath);
             Assert.AreEqual<string>(string.Format(@"/resultsfile:""{0}"" /test:TestConsoleExtended /test:TestConsoleExtended_Second", newTestResultsPath), additionalArguments);
         }
+
+        [TestMethod]
+        public void ExcludeTestListFromConsoleArguments_WhenTestListPresent()
+        {
+            var log = Mock.Create<ILog>();
+            Mock.Arrange(() => log.Info(Arg.AnyString));
+            var consoleArgumentsProvider = Mock.Create<IConsoleArgumentsProvider>();
+            string newTestResultsPath = Path.GetTempFileName();
+            Mock.Arrange(() => consoleArgumentsProvider.ConsoleArguments).Returns(@"/resultsfile:""C:\Results.trx"" /test:testmask1 /test:testmask2 /retriesCount:3");
+            Mock.Arrange(() => consoleArgumentsProvider.TestResultPath).Returns(@"C:\Results.trx");
+            var fileSystemProvider = new FileSystemProvider(consoleArgumentsProvider);
+            var testRun = fileSystemProvider.DeserializeTestRun("Exceptions.trx");
+
+            var microsoftTestTestRunProvider = new MsTestTestRunProvider(consoleArgumentsProvider, log);
+            string additionalArguments = microsoftTestTestRunProvider.GenerateAdditionalArgumentsForFailedTestsRun(testRun.Results.ToList(), newTestResultsPath);
+
+            // Check if "/test:testmask1 /test:testmask2" parameters are removed from command line arguments
+            Assert.AreEqual<string>(string.Format(@"/resultsfile:""{0}""   /retriesCount:3 /test:TestConsoleExtended /test:TestConsoleExtended_Second", newTestResultsPath), additionalArguments);
+        }
     }
 }

--- a/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
@@ -23,8 +23,8 @@ namespace MSTest.Console.Extended.Infrastructure
 {
     public class ConsoleArgumentsProvider : IConsoleArgumentsProvider
     {
-        private readonly string testResultFilePathRegexPattern = @".*resultsfile:(?<ResultsFilePath>[1-9A-Za-z\\:._]{1,})";
-        private readonly string testNewResultFilePathRegexPattern = @".*(?<NewResultsFilePathArgument>/newResultsfile:(?<NewResultsFilePath>[1-9A-Za-z\\:._]{1,}))";
+        private readonly string testResultFilePathRegexPattern = @".*resultsfile:(?<ResultsFilePath>[0-9A-Za-z\\:._-]{1,})";
+        private readonly string testNewResultFilePathRegexPattern = @".*(?<NewResultsFilePathArgument>/newResultsfile:(?<NewResultsFilePath>[0-9A-Za-z\\:._-]{1,}))";
         private readonly string retriesRegexPattern = @".*(?<RetriesArgument>/retriesCount:(?<RetriesCount>[0-9]{1})).*";
         private readonly string failedTestsThresholdRegexPattern = @".*(?<ThresholdArgument>/threshold:(?<ThresholdCount>[0-9]{1,3})).*";
         private readonly string deleteOldFilesRegexPattern = @".*(?<DeleteOldFilesArgument>/deleteOldResultsFiles:(?<DeleteOldFilesValue>[a-zA-Z]{4,5})).*";

--- a/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
@@ -58,7 +58,7 @@ namespace MSTest.Console.Extended.Infrastructure
             Match currentMatch = r1.Match(this.ConsoleArguments);
             if (!currentMatch.Success)
             {
-                throw new ArgumentException("You need to specify path to test results.");
+                throw new ArgumentException("You need to specify path to test results. Paths with spaces are not supported");
             }
             this.TestResultPath = currentMatch.Groups["ResultsFilePath"].Value;
         }

--- a/MSTest.Console/MSTest.Console.Extended/Infrastructure/FileSystemProvider.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Infrastructure/FileSystemProvider.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Xml.Serialization;
 using MSTest.Console.Extended.Data;
 using MSTest.Console.Extended.Interfaces;
+using System;
 
 namespace MSTest.Console.Extended.Infrastructure
 {
@@ -51,6 +52,10 @@ namespace MSTest.Console.Extended.Infrastructure
                 StreamReader reader = new StreamReader(resultsPath);
                 testRun = (TestRun)serializer.Deserialize(reader);
                 reader.Close();
+            }
+            else
+            {
+                throw new ArgumentException(string.Format("Cannot deserialize {0}", resultsPath));
             }
             return testRun;
         }

--- a/MSTest.Console/MSTest.Console.Extended/Infrastructure/MsTestTestRunProvider.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Infrastructure/MsTestTestRunProvider.cs
@@ -84,23 +84,29 @@ namespace MSTest.Console.Extended.Infrastructure
                 this.log.InfoFormat("##### MSTestRetrier: Execute again {0}", currentFailedTest.testName);
             }
 
-            string oldAgruments = this.consoleArgumentsProvider.ConsoleArguments;
+            string oldArgmentsWithoutTestList = ExcludeTestListFromConsoleArguments(this.consoleArgumentsProvider.ConsoleArguments);
 
-            // Exclude original test list from command line arguments
-            Regex r1 = new Regex(testToRunRegexPattern, RegexOptions.Singleline);
-            foreach (Match currentMatch in r1.Matches(oldAgruments))
-            {
-                if (currentMatch.Success)
-                {
-                    oldAgruments = oldAgruments.Replace(currentMatch.Groups[0].Value, "");
-                }
-            }
-
-            string additionalArgumentsForFailedTestsRun = string.Concat(oldAgruments, sb.ToString());
+            string additionalArgumentsForFailedTestsRun = string.Concat(oldArgmentsWithoutTestList, sb.ToString());
 
             additionalArgumentsForFailedTestsRun = additionalArgumentsForFailedTestsRun.Replace(this.consoleArgumentsProvider.TestResultPath, newTestResultFilePath);
             additionalArgumentsForFailedTestsRun = additionalArgumentsForFailedTestsRun.TrimEnd();
             return additionalArgumentsForFailedTestsRun;
+        }
+
+        private string ExcludeTestListFromConsoleArguments(string oldArguments)
+        {
+            string oldArgmentsWithoutTestList = oldArguments;
+
+            Regex r1 = new Regex(testToRunRegexPattern, RegexOptions.Singleline);
+            foreach (Match currentMatch in r1.Matches(oldArguments))
+            {
+                if (currentMatch.Success)
+                {
+                    oldArgmentsWithoutTestList = oldArgmentsWithoutTestList.Replace(currentMatch.Groups[0].Value, "");
+                }
+            }
+            
+            return oldArgmentsWithoutTestList;
         }
 
         public int CalculatedFailedTestsPercentage(List<TestRunUnitTestResult> failedTests, List<TestRunUnitTestResult> allTests)

--- a/MSTest.Console/MSTest.Console.Extended/Services/TestExecutionService.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Services/TestExecutionService.cs
@@ -80,6 +80,10 @@ namespace MSTest.Console.Extended.Services
                     failedTests = this.microsoftTestTestRunProvider.GetAllNotPassedTests(testRun.Results.ToList());
                 }
             }
+            else
+            {
+                this.log.InfoFormat("Percentage of failed tests {0} is over threshold {1}, will not restart", failedTestsPercentage, this.consoleArgumentsProvider.FailedTestsThreshold);
+            }
             if (failedTests.Count > 0)
             {
                 areAllTestsGreen = 1;


### PR DESCRIPTION
Here are the patches that allowed to use MSTest.Console.Extended in our environment.

resultsFile regex did not allow to have .trx file with '0' and '-' chars in filename.

We often run tests by specifying several test name masks like /test:ABC /test:XYZ. Before our patch these switches were copied to the rerun command line and all tests were rerun. Now only failed tests are rerun.

We also added error messages that helped us to understand what causes the errors like 
```
ERROR MSTest.Console.Extended.Program - Object reference not set to an instance of an object.   
at MSTest.Console.Extended.Services.TestExecutionService.ExecuteWithRetry()
```