### PR TITLE
Allow spaces and @ symbol in file path args

### DIFF
--- a/MSTest.Console/MSTest.Console.Extended.UnitTests/ConsoleArgumentsProviderTests/ConsoleArgumentsProvider_Constructor_Should.cs
+++ b/MSTest.Console/MSTest.Console.Extended.UnitTests/ConsoleArgumentsProviderTests/ConsoleArgumentsProvider_Constructor_Should.cs
@@ -89,6 +89,23 @@ namespace MSTest.Console.Extended.UnitTests.ConsoleArgumentsProviderTests
         }
 
         [TestMethod]
+        public void SetTestResultsPath_WhenTestResultsPathContainsAtSymbol()
+        {
+            string[] args = 
+            {
+                @"/resultsfile:C:\Results@FF.trx",
+                @"/testcontainer:C:\Frontend\Tests.dll",
+                "/nologo",
+                "/category:MSTestConsoleExtendedTEST",
+                "/retriesCount:3",
+                "/deleteOldResultsFiles:true",
+                @"/newResultsfile:C:\ResultsNew.trx"
+            };
+            var consoleArgumentsProvider = new ConsoleArgumentsProvider(args);
+            Assert.AreEqual<string>(@"C:\Results@FF.trx", consoleArgumentsProvider.TestResultPath);
+        }
+
+        [TestMethod]
         public void SetTestResultsPath_WhenTestResultsPathContainsDigit()
         {
             string[] args = 
@@ -187,6 +204,23 @@ namespace MSTest.Console.Extended.UnitTests.ConsoleArgumentsProviderTests
             };
             var consoleArgumentsProvider = new ConsoleArgumentsProvider(args);
             Assert.AreEqual<string>(@"C:\ResultsNew1.trx", consoleArgumentsProvider.NewTestResultPath);
+        }
+
+        [TestMethod]
+        public void SetNewTestResultsPath_WhenNewTestResultsPathContainsAtSymbol()
+        {
+            string[] args =
+            {
+                @"/resultsfile:C:\Results1.trx",
+                @"/testcontainer:C:\Frontend\Tests.dll",
+                "/nologo",
+                "/category:MSTestConsoleExtendedTEST",
+                "/retriesCount:3",
+                "/deleteOldResultsFiles:true",
+                @"/newResultsfile:C:\Results@1\New1.trx"
+            };
+            var consoleArgumentsProvider = new ConsoleArgumentsProvider(args);
+            Assert.AreEqual<string>(@"C:\Results@1\New1.trx", consoleArgumentsProvider.NewTestResultPath);
         }
 
         [TestMethod]

--- a/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
+++ b/MSTest.Console/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
@@ -23,8 +23,8 @@ namespace MSTest.Console.Extended.Infrastructure
 {
     public class ConsoleArgumentsProvider : IConsoleArgumentsProvider
     {
-        private readonly string testResultFilePathRegexPattern = @".*resultsfile:(?<ResultsFilePath>[0-9A-Za-z\\:._-]{1,})";
-        private readonly string testNewResultFilePathRegexPattern = @".*(?<NewResultsFilePathArgument>/newResultsfile:(?<NewResultsFilePath>[0-9A-Za-z\\:._-]{1,}))";
+        private readonly string testResultFilePathRegexPattern = @".*resultsfile:(?<ResultsFilePath>[0-9A-Za-z\\:._@\s-]{1,})";
+        private readonly string testNewResultFilePathRegexPattern = @".*(?<NewResultsFilePathArgument>/newResultsfile:(?<NewResultsFilePath>[0-9A-Za-z\\:._@\s-]{1,}))";
         private readonly string retriesRegexPattern = @".*(?<RetriesArgument>/retriesCount:(?<RetriesCount>[0-9]{1})).*";
         private readonly string failedTestsThresholdRegexPattern = @".*(?<ThresholdArgument>/threshold:(?<ThresholdCount>[0-9]{1,3})).*";
         private readonly string deleteOldFilesRegexPattern = @".*(?<DeleteOldFilesArgument>/deleteOldResultsFiles:(?<DeleteOldFilesValue>[a-zA-Z]{4,5})).*";
@@ -60,7 +60,7 @@ namespace MSTest.Console.Extended.Infrastructure
             {
                 throw new ArgumentException("You need to specify path to test results. Paths with spaces are not supported");
             }
-            this.TestResultPath = currentMatch.Groups["ResultsFilePath"].Value;
+            this.TestResultPath = currentMatch.Groups["ResultsFilePath"].Value.Trim();
         }
 
         private void InitializeNewTestResultsPath()
@@ -73,7 +73,7 @@ namespace MSTest.Console.Extended.Infrastructure
             }
             else
             {
-                this.NewTestResultPath = currentMatch.Groups["NewResultsFilePath"].Value;
+                this.NewTestResultPath = currentMatch.Groups["NewResultsFilePath"].Value.Trim();
                 this.ConsoleArguments = this.ConsoleArguments.Replace(currentMatch.Groups["NewResultsFilePathArgument"].Value, string.Empty);
             }
         }


### PR DESCRIPTION
Jenkins uses `@` in the directory path when running a build concurrently. Parsing the newResultsFile would also fail if the path contained any spaces.